### PR TITLE
Support servers only offering EWS/Services.wsdl instead of EWS/Exchange.asmx

### DIFF
--- a/src/java/davmail/exchange/ExchangeSessionFactory.java
+++ b/src/java/davmail/exchange/ExchangeSessionFactory.java
@@ -187,8 +187,8 @@ public final class ExchangeSessionFactory {
 
                 } else if (Settings.EWS.equals(mode) || Settings.O365.equals(mode)
                             // direct EWS even if mode is different
-                            || poolKey.url.toLowerCase().endsWith("/ews/exchange.asmx")) {
-                    if (poolKey.url.toLowerCase().endsWith("/ews/exchange.asmx")) {
+                            || poolKey.url.toLowerCase().endsWith("/ews/exchange.asmx") || poolKey.url.toLowerCase().endsWith("/ews/services.wsdl")) {
+                    if (poolKey.url.toLowerCase().endsWith("/ews/exchange.asmx") || poolKey.url.toLowerCase().endsWith("/ews/services.wsdl")) {
                         ExchangeSession.LOGGER.debug("Direct EWS authentication");
                         HttpClient httpClient = DavGatewayHttpClientFacade.getInstance(poolKey.url);
                         DavGatewayHttpClientFacade.createMultiThreadedHttpConnectionManager(httpClient);


### PR DESCRIPTION
I want to connect to a server which does not offer `EWS/Exchange.asmx` but instead offers `EWS/Services.wsdl`. Without this patch, Davmail stops with a `401 Unauthorized` error. With this patch, everything works as expected.